### PR TITLE
Remove path as dependency. It's in node core now. Fixed #6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "grunt": "~0.3.17"
   },
   "dependencies":{
-    "path":">= 0.0.1",
     "node-imagemagick":""
   },
   "keywords": [


### PR DESCRIPTION
It's actually impossible to install this with npm 0.10.x at all, see #6
