### PR TITLE
make error handling configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ grunt.initConfig({
 This is only working for
 * imagemagick-resize
 * imagemagick-convert
+
 # Tasks
 __imagemagick-convert__
 Use the _args_ property to identify the list of arguments to pass to ImageMagick's convert command.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ grunt.initConfig({
 	}
 });
 ```
+### Error Handling
+Errors comming from the underlying cli are just displayed as default, you can get a warning thrown if you like by configuring a flag:
+```javascript
+grunt.initConfig({
+	"imagemagick-convert":{
+	  dev:{
+	    args:['test/resizeme.jpg','-resize', '25x25', 'test/resized/resizeme-small.jpg'],
+	    fatals: true
+	  }
+	}
+});
+```
+This is only working for
+* imagemagick-resize
+* imagemagick-convert
 # Tasks
 __imagemagick-convert__
 Use the _args_ property to identify the list of arguments to pass to ImageMagick's convert command.

--- a/tasks/imagemagick.js
+++ b/tasks/imagemagick.js
@@ -112,10 +112,13 @@ var ResizeCommand={
     this.im.resize(this.props,proxy(this.complete,this));
   },
   complete:function(err){
-    if (err !== undefined && this.context.data.fatals === true) {
-      grunt.warn('processing '+this.props.dstPath+'--'+err+"\n");
-	} else {
-      grunt.log.write('created '+this.props.dstPath+'--'+err+"\n");
+    grunt.log.write('created '+this.props.dstPath+'--'+err+"\n");
+    if (err !== undefined && err !== null) {
+      if (this.context.data.fatals === true) {
+        grunt.warn(err);
+	  } else {
+	    grunt.log.write('error: '+err+"\n");
+	  }
 	}
     this.callback.apply(this.context,[this,true]);
   }
@@ -141,11 +144,14 @@ var ConvertCommand={
     this.im.convert(this.args,proxy(this.complete,this));
   },
   complete:function(err){
-    if (err !== undefined && this.context.data.fatals === true) {
-      grunt.warn('processing '+this.args+'--'+err+"\n");
-	} else {
-      grunt.log.write('convert complete...'+"\n"+err+"\n");
-    }
+    grunt.log.write('convert complete...'+"\n"+err+"\n");
+    if (err !== undefined && err !== null) {
+      if (this.context.data.fatals === true) {
+        grunt.warn(err);
+	  } else {
+	    grunt.log.write('error: '+err+"\n");
+	  }
+	}
     this.callback.apply(this.context,[this,true]);
   }
 };

--- a/tasks/imagemagick.js
+++ b/tasks/imagemagick.js
@@ -112,7 +112,7 @@ var ResizeCommand={
     this.im.resize(this.props,proxy(this.complete,this));
   },
   complete:function(err){
-    grunt.log.write('created '+this.props.dstPath+'--'+err+"\n");
+    grunt.log.write('created '+this.props.dstPath+"\n");
     if (err !== undefined && err !== null) {
       if (this.context.data.fatals === true) {
         grunt.warn(err);
@@ -144,7 +144,7 @@ var ConvertCommand={
     this.im.convert(this.args,proxy(this.complete,this));
   },
   complete:function(err){
-    grunt.log.write('convert complete...'+"\n"+err+"\n");
+    grunt.log.write('convert complete...'+"\n");
     if (err !== undefined && err !== null) {
       if (this.context.data.fatals === true) {
         grunt.warn(err);

--- a/tasks/imagemagick.js
+++ b/tasks/imagemagick.js
@@ -112,7 +112,11 @@ var ResizeCommand={
     this.im.resize(this.props,proxy(this.complete,this));
   },
   complete:function(err){
-    grunt.log.write('created '+this.props.dstPath+'--'+err+"\n");
+    if (err !== undefined && this.context.data.fatals === true) {
+      grunt.warn('processing '+this.props.dstPath+'--'+err+"\n");
+	} else {
+      grunt.log.write('created '+this.props.dstPath+'--'+err+"\n");
+	}
     this.callback.apply(this.context,[this,true]);
   }
 };
@@ -137,7 +141,11 @@ var ConvertCommand={
     this.im.convert(this.args,proxy(this.complete,this));
   },
   complete:function(err){
-    grunt.log.write('convert complete...'+"\n"+err+"\n");
+    if (err !== undefined && this.context.data.fatals === true) {
+      grunt.warn('processing '+this.args+'--'+err+"\n");
+	} else {
+      grunt.log.write('convert complete...'+"\n"+err+"\n");
+    }
     this.callback.apply(this.context,[this,true]);
   }
 };

--- a/tasks/imagemagick.js
+++ b/tasks/imagemagick.js
@@ -213,7 +213,7 @@ module.exports = function(grunt) {
     var fls=grunt.file.expand(this.data.from+this.data.files);
 
     function onCmdComplete(cmd,success){
-      grunt.log.write("completed:"+cmd.dstPath+"\n");
+      grunt.log.write("completed:"+cmd.props.dstPath+"\n");
       cmds.splice(cmds.indexOf(cmd),1);
       if(cmds.length<1){
         done();


### PR DESCRIPTION
As discussed in issue #7 it is often better to have errors from imagemagick cli to interrupt the grunt workflow. Probably you want to optimize the README text, sorry for my english...
